### PR TITLE
Added support for Gson configuration. (useful for Date format)

### DIFF
--- a/jsonrpc-java/src/main/java/org/json/rpc/client/JsonRpcInvoker.java
+++ b/jsonrpc-java/src/main/java/org/json/rpc/client/JsonRpcInvoker.java
@@ -42,12 +42,23 @@ public final class JsonRpcInvoker {
 
     private final TypeChecker typeChecker;
 
+    private final Gson gson;
+
     public JsonRpcInvoker() {
-        this(new GsonTypeChecker());
+        this(new GsonTypeChecker(), new Gson());
+    }
+
+    public JsonRpcInvoker(Gson gson) {
+        this(new GsonTypeChecker(), gson);
     }
 
     public JsonRpcInvoker(TypeChecker typeChecker) {
+        this(typeChecker, new Gson());
+    }
+
+    public JsonRpcInvoker(TypeChecker typeChecker, Gson gson) {
         this.typeChecker = typeChecker;
+		this.gson = gson;
     }
 
     public <T> T get(final JsonRpcClientTransport transport, final String handle, final Class<T>... classes) {
@@ -55,7 +66,6 @@ public final class JsonRpcInvoker {
             typeChecker.isValidInterface(clazz);
         }
         return (T) Proxy.newProxyInstance(JsonRpcInvoker.class.getClassLoader(), classes, new InvocationHandler() {
-
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
                 return JsonRpcInvoker.this.invoke(handle, transport, method, args);
             }
@@ -67,8 +77,6 @@ public final class JsonRpcInvoker {
                           Object[] args) throws Throwable {
         int id = rand.nextInt(Integer.MAX_VALUE);
         String methodName = handleName + "." + method.getName();
-
-        Gson gson = new Gson();
 
         JsonObject req = new JsonObject();
         req.addProperty("id", id);

--- a/jsonrpc-java/src/main/java/org/json/rpc/server/JsonRpcExecutor.java
+++ b/jsonrpc-java/src/main/java/org/json/rpc/server/JsonRpcExecutor.java
@@ -56,14 +56,25 @@ public final class JsonRpcExecutor implements RpcIntroSpection {
 
     private final TypeChecker typeChecker;
     private volatile boolean locked;
+    
+    private final Gson gson;
 
     public JsonRpcExecutor() {
-        this(new GsonTypeChecker());
+        this(new GsonTypeChecker(), new Gson());
+    }
+
+    public JsonRpcExecutor(Gson gson) {
+        this(new GsonTypeChecker(), gson);
+    }
+
+    public JsonRpcExecutor(TypeChecker typeChecker) {
+    	this(typeChecker, new Gson());
     }
 
     @SuppressWarnings("unchecked")
-    public JsonRpcExecutor(TypeChecker typeChecker) {
+    public JsonRpcExecutor(TypeChecker typeChecker, Gson gson) {
         this.typeChecker = typeChecker;
+		this.gson = gson;
         this.handlers = new HashMap<String, HandleEntry<?>>();
         addHandler("system", this, RpcIntroSpection.class);
     }
@@ -239,7 +250,7 @@ public final class JsonRpcExecutor implements RpcIntroSpection {
             Object result = executableMethod.invoke(
                     handleEntry.getHandler(), getParameters(executableMethod, params));
 
-            return new Gson().toJsonTree(result);
+            return gson.toJsonTree(result);
         } catch (Throwable t) {
             if (t instanceof InvocationTargetException) {
                 t = ((InvocationTargetException) t).getTargetException();
@@ -261,7 +272,6 @@ public final class JsonRpcExecutor implements RpcIntroSpection {
 
     public Object[] getParameters(Method method, JsonArray params) {
         List<Object> list = new ArrayList<Object>();
-        Gson gson = new Gson();
         Class<?>[] types = method.getParameterTypes();
         for (int i = 0; i < types.length; i++) {
             JsonElement p = params.get(i);


### PR DESCRIPTION
This change allows for providing custom Gson instance with custom serializers and deserializers or just custom date format. Or, you can keep default Gson instance for backward compatibility.

Current JSON-RPC uses the default Gson instance which uses an incomplete date format with no time zone and doesn't provide any way for changing it. This results in wrong time offsets when the client is on different timezone from the server.

Note that this change doesn't change the default date format and only provides a way to do so. JSON doesn't specify a date format.

A side-effect of the change is using a single Gson instance instead of creating new instance with each method invocation. Gson is thread safe.
