### PR TITLE
Fixed bug - false detection of circular reference

### DIFF
--- a/jsonrpc-java/src/main/java/org/json/rpc/client/JsonRpcInvoker.java
+++ b/jsonrpc-java/src/main/java/org/json/rpc/client/JsonRpcInvoker.java
@@ -42,12 +42,23 @@ public final class JsonRpcInvoker {
 
     private final TypeChecker typeChecker;
 
+    private final Gson gson;
+
     public JsonRpcInvoker() {
-        this(new GsonTypeChecker());
+        this(new GsonTypeChecker(), new Gson());
+    }
+
+    public JsonRpcInvoker(Gson gson) {
+        this(new GsonTypeChecker(), gson);
     }
 
     public JsonRpcInvoker(TypeChecker typeChecker) {
+        this(typeChecker, new Gson());
+    }
+
+    public JsonRpcInvoker(TypeChecker typeChecker, Gson gson) {
         this.typeChecker = typeChecker;
+		this.gson = gson;
     }
 
     public <T> T get(final JsonRpcClientTransport transport, final String handle, final Class<T>... classes) {
@@ -55,7 +66,6 @@ public final class JsonRpcInvoker {
             typeChecker.isValidInterface(clazz);
         }
         return (T) Proxy.newProxyInstance(JsonRpcInvoker.class.getClassLoader(), classes, new InvocationHandler() {
-
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
                 return JsonRpcInvoker.this.invoke(handle, transport, method, args);
             }
@@ -67,8 +77,6 @@ public final class JsonRpcInvoker {
                           Object[] args) throws Throwable {
         int id = rand.nextInt(Integer.MAX_VALUE);
         String methodName = handleName + "." + method.getName();
-
-        Gson gson = new Gson();
 
         JsonObject req = new JsonObject();
         req.addProperty("id", id);

--- a/jsonrpc-java/src/main/java/org/json/rpc/commons/GsonTypeChecker.java
+++ b/jsonrpc-java/src/main/java/org/json/rpc/commons/GsonTypeChecker.java
@@ -85,7 +85,7 @@ public class GsonTypeChecker extends TypeChecker {
         }
 
         boolean zeroArgConstructor = (clazz.getConstructors().length == 0);
-        for (Constructor c : clazz.getConstructors()) {
+        for (Constructor<?> c : clazz.getConstructors()) {
             if (c.getParameterTypes().length == 0) {
                 zeroArgConstructor = true;
                 break;
@@ -100,14 +100,12 @@ public class GsonTypeChecker extends TypeChecker {
         }
 
         // avoid circular references
-        visited = (visited == null ? new HashSet<Class<?>>() : visited);
-        if (visited.contains(clazz)) {
-            if (throwException) {
-                throw new IllegalArgumentException("circular reference detected : " + clazz);
-            }
+        if(visited == null) visited = new HashSet<Class<?>>();
+        if (!visited.add(clazz)) {
+            if (throwException)
+				throw new IllegalArgumentException("circular reference detected : " + clazz);
             return false;
         }
-        visited.add(clazz);
 
         // Check for fields because Gson uses fields
         for (Field f : clazz.getDeclaredFields()) {
@@ -142,6 +140,7 @@ public class GsonTypeChecker extends TypeChecker {
             }
         }
 
+        visited.remove(clazz);
 
         return true;
     }

--- a/jsonrpc-java/src/main/java/org/json/rpc/server/JsonRpcExecutor.java
+++ b/jsonrpc-java/src/main/java/org/json/rpc/server/JsonRpcExecutor.java
@@ -56,14 +56,25 @@ public final class JsonRpcExecutor implements RpcIntroSpection {
 
     private final TypeChecker typeChecker;
     private volatile boolean locked;
+    
+    private final Gson gson;
 
     public JsonRpcExecutor() {
-        this(new GsonTypeChecker());
+        this(new GsonTypeChecker(), new Gson());
+    }
+
+    public JsonRpcExecutor(Gson gson) {
+        this(new GsonTypeChecker(), gson);
+    }
+
+    public JsonRpcExecutor(TypeChecker typeChecker) {
+    	this(typeChecker, new Gson());
     }
 
     @SuppressWarnings("unchecked")
-    public JsonRpcExecutor(TypeChecker typeChecker) {
+    public JsonRpcExecutor(TypeChecker typeChecker, Gson gson) {
         this.typeChecker = typeChecker;
+		this.gson = gson;
         this.handlers = new HashMap<String, HandleEntry<?>>();
         addHandler("system", this, RpcIntroSpection.class);
     }
@@ -239,7 +250,7 @@ public final class JsonRpcExecutor implements RpcIntroSpection {
             Object result = executableMethod.invoke(
                     handleEntry.getHandler(), getParameters(executableMethod, params));
 
-            return new Gson().toJsonTree(result);
+            return gson.toJsonTree(result);
         } catch (Throwable t) {
             if (t instanceof InvocationTargetException) {
                 t = ((InvocationTargetException) t).getTargetException();
@@ -261,7 +272,6 @@ public final class JsonRpcExecutor implements RpcIntroSpection {
 
     public Object[] getParameters(Method method, JsonArray params) {
         List<Object> list = new ArrayList<Object>();
-        Gson gson = new Gson();
         Class<?>[] types = method.getParameterTypes();
         for (int i = 0; i < types.length; i++) {
             JsonElement p = params.get(i);


### PR DESCRIPTION
There was a bug in detection of circular reference.

It was adding the class of each field as it was entering it, but it wasn't removing it once it exists the field.
As a result, any class with 2 or more fields of the same class was wrongly giving an error.

Added 
visited.remove(clazz);
to fix it.

Note the pull request has 2 commits even though one is already merged.
The fix consists only of commit https://github.com/parvanov/jsonrpc/commit/e89c8b7a2c6cf758544177ebbbdaf300dba2dba8
